### PR TITLE
Fix unexpected MOODLE_INTERNAL check no side effects

### DIFF
--- a/block_snapfeeds.php
+++ b/block_snapfeeds.php
@@ -24,8 +24,6 @@
 
 use theme_snap\output\ce_render_helper;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Snap feeds block class.
  *

--- a/classes/api/block_replacer.php
+++ b/classes/api/block_replacer.php
@@ -24,8 +24,6 @@
 
 namespace block_snapfeeds\api;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Block replacer.
  *

--- a/classes/event_handlers.php
+++ b/classes/event_handlers.php
@@ -25,8 +25,6 @@ namespace block_snapfeeds;
 use block_snapfeeds\api\block_replacer;
 use core\event\base;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Event handlers class.
  *

--- a/classes/privacy/provider.php
+++ b/classes/privacy/provider.php
@@ -24,8 +24,6 @@
 
 namespace block_snapfeeds\privacy;
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Privacy Subsystem for block_snapfeeds implementing null_provider.
  *

--- a/edit_form.php
+++ b/edit_form.php
@@ -22,8 +22,6 @@
  * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
  */
 
-defined('MOODLE_INTERNAL') || die();
-
 /**
  * Form for Snap feeds instances.
  *

--- a/tests/replace_test.php
+++ b/tests/replace_test.php
@@ -24,8 +24,6 @@
 
 use block_snapfeeds\api\block_replacer;
 
-defined('MOODLE_INTERNAL') || die();
-
 class block_snapfeeds_replace_test extends advanced_testcase  {
 
     protected function setUp(): void {


### PR DESCRIPTION
This pull request resolves the next warning throughout the repository:

-Unexpected MOODLE_INTERNAL check. No side effects or multiple artifacts detected.